### PR TITLE
Add DeepAlpha - AI crypto trading bot

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -59,6 +59,10 @@ projects:
     github_id: Erio-Harrison/rust-trade
     category: bots-frameworks
     labels: ["rust"]
+  - name: DeepAlpha
+    github_id: stefanoviana/deepalpha
+    category: bots-frameworks
+    labels: ["python"]
   - name: QTradeX
     github_id: squidKid-deluxe/QTradeX-Algo-Trading-SDK
     category: bots-frameworks


### PR DESCRIPTION
## Description

Adding [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the Bots & Frameworks category.

**DeepAlpha** is an open-source AI-powered crypto trading bot featuring:
- 3-model ML ensemble (XGBoost, LightGBM, CatBoost)
- 12 exchanges supported via CCXT
- Grid trading, DCA with safety orders
- Walk-forward validation
- Python-based with FastAPI dashboard

Thank you for maintaining this best-of list!