### PR TITLE
Add project: ml-quant-trading

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -543,6 +543,11 @@ projects:
   - name: machine-learning-for-trading
     github_id: stefan-jansen/machine-learning-for-trading
     category: libraries-api
+  - name: ml-quant-trading
+    github_id: initial-d/ml-quant-trading
+    category: libraries-api
+    labels: ["python"]
+    description: "PyTorch research stack for multi-factor modeling, portfolio optimization, and vectorized backtesting."
   - name: StockSharp
     github_id: StockSharp/StockSharp
     category: bots-frameworks


### PR DESCRIPTION
Adds `initial-d/ml-quant-trading` to `projects.yaml` as a Python research stack for algorithmic-trading experimentation.

Why it fits this list:

- Python/PyTorch project focused on multi-factor modeling, portfolio optimization, and vectorized backtesting.
- Research-oriented rather than a closed signal service or live-trading bot.
- Includes documentation around validation limits, public/synthetic data runs, and reproducibility notes.

Affiliation disclosure: I am the author/maintainer of `ml-quant-trading`.