### PR TITLE
Add project: AlphaAI

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -576,3 +576,9 @@ projects:
     resource: True
     category: libraries-api
     description: "Market sentiment API for stock tickers, combining Reddit, X/Twitter, and Polymarket signals with buzz scores and trend analytics."
+
+  - name: AlphaAI
+    homepage: "https://alphai.io/developers"
+    resource: True
+    category: libraries-api
+    description: "AI-scored financial news API for trading bots: 1-10 relevance per article, ticker-linked, plus SEC Form 4 insider events. REST and MCP, free tier."


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Adds **AlphaAI** to the Libraries & API category, in the same `resource` form as PredScope and Adanos Market Sentiment API.

AlphaAI is a financial news API aimed at trading bots and AI agents. Every article is enriched with per-ticker analysis, a category and a 1 to 10 relevance score, so a strategy can filter on signal strength instead of parsing headlines. It also carries SEC Form 4 insider events, one row per filing transaction group, with the structured transaction data behind them.

Two surfaces:
* REST API with an OpenAPI 3.1 spec at https://alphai.io/api/schema/ (docs: https://alphai.io/developers)
* Hosted MCP server at https://mcp.alphai.io for agent frameworks (docs: https://alphai.io/mcp)

Free tier is 20 requests/min and 100/day on both, no card required. Python and TypeScript clients are on PyPI and npm.

Disclosure: I build AlphaAI.

Validation:
* `curl -L -s -o /dev/null -w "%{http_code}\n" https://alphai.io/developers` returns `200`
* `python3 -c "import yaml; d=yaml.safe_load(open('projects.yaml'))"` parses cleanly, 114 projects, project names still unique

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
