### PR TITLE
Add project: Shingou

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -576,3 +576,9 @@ projects:
     resource: True
     category: libraries-api
     description: "Market sentiment API for stock tickers, combining Reddit, X/Twitter, and Polymarket signals with buzz scores and trend analytics."
+
+  - name: Shingou
+    homepage: "https://shingou.io/docs"
+    resource: True
+    category: libraries-api
+    description: "Crypto news sentiment API. One signal per symbol per hour, with typed market events and point-in-time history for backtesting. Free tier covers BTC, ETH and SOL live."


### PR DESCRIPTION
One project, added to `projects.yaml` as a `resource` entry under `libraries-api`, beside the other hosted APIs.

Shingou is an hourly crypto news sentiment API. One signal per symbol per hour for 30 pairs, with typed market events (hack, regulation, listing, delisting, legal) and point-in-time buckets meant for backtesting. Every hourly bucket's hash is committed to a public append-only log at publish time, so the history can be checked for rewrites before anyone tests against it. The log repo ships a one-command verifier that runs on a free key.

Free tier: 1,000 requests a day, live on BTC, ETH and SOL, 1 day of history depth, no card, non-commercial use. Paid plans are $24, $79 and $249 a month before VAT.

- Docs and endpoint reference: https://shingou.io/docs
- Hash log and verifier: https://github.com/shingou-io/shingou-signal-log
- Example integrations, MIT, Freqtrade and Jesse: https://github.com/shingou-io/shingou-integrations
- Published backtest, negative results kept: https://shingou.io/research

Checked against CONTRIBUTING.md: one project in this PR, title in the `Add project: <name>` form, only `projects.yaml` touched, the name is unique in the file, `libraries-api` is an existing category, and the entry uses the same `resource` / `homepage` / `description` shape as the neighbouring API entries. The YAML parses and the project count goes 113 to 114.
